### PR TITLE
Fix endpoint issues for gh enterprise, closes #6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,13 +13,14 @@ var Organization = require('./organization');
 var Application = require('./application');
 var pagination = require('./pagination');
 
+var DEFAULT_GITHUB_ENDPOINT = "https://api.github.com";
 
 var GitHub = function(opts) {
     if (!(this instanceof GitHub)) return new GitHub(opts);
 
     this.opts = _.defaults(opts || {}, {
         // Endpoint for the API
-        endpoint: "https://api.github.com",
+        endpoint: DEFAULT_GITHUB_ENDPOINT,
 
         // User-Agent to use for requests
         userAgent: "octocat.js",
@@ -105,8 +106,14 @@ GitHub.prototype.request = function(httpMethod, method, params, opts) {
 
     httpMethod = httpMethod.toUpperCase();
 
-    // Build url
-    uri = url.resolve(this.opts.endpoint, method);
+    // Build url, don't use url.resolve() for github enterprise endpoints:
+    // https://nodejs.org/api/url.html#url_url_resolve_from_to
+    // https://developer.github.com/v3/enterprise/#endpoint-urls
+    if (this.opts.endpoint === DEFAULT_GITHUB_ENDPOINT) {
+        uri = url.resolve(this.opts.endpoint, method);
+    } else {
+        uri = this.opts.endpoint + method;
+    }
     if (httpMethod == 'GET') uri = uri + '?' + querystring.stringify(params || {});
 
     // Build request

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var Q = require('q');
 var url = require('url');
+var join = require('url-join');
 var base64 = require('js-base64').Base64;
 var querystring = require('querystring');
 var request = require('request');
@@ -13,14 +14,12 @@ var Organization = require('./organization');
 var Application = require('./application');
 var pagination = require('./pagination');
 
-var DEFAULT_GITHUB_ENDPOINT = "https://api.github.com";
-
 var GitHub = function(opts) {
     if (!(this instanceof GitHub)) return new GitHub(opts);
 
     this.opts = _.defaults(opts || {}, {
         // Endpoint for the API
-        endpoint: DEFAULT_GITHUB_ENDPOINT,
+        endpoint: "https://api.github.com",
 
         // User-Agent to use for requests
         userAgent: "octocat.js",
@@ -106,14 +105,7 @@ GitHub.prototype.request = function(httpMethod, method, params, opts) {
 
     httpMethod = httpMethod.toUpperCase();
 
-    // Build url, don't use url.resolve() for github enterprise endpoints:
-    // https://nodejs.org/api/url.html#url_url_resolve_from_to
-    // https://developer.github.com/v3/enterprise/#endpoint-urls
-    if (this.opts.endpoint === DEFAULT_GITHUB_ENDPOINT) {
-        uri = url.resolve(this.opts.endpoint, method);
-    } else {
-        uri = this.opts.endpoint + method;
-    }
+    uri = join(this.opts.endpoint, method);
     if (httpMethod == 'GET') uri = uri + '?' + querystring.stringify(params || {});
 
     // Build request

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
-    "name": "octocat",
-    "version": "0.11.0",
-    "description": "GitHub API client in Javascript (Node.js and Browser)",
-    "author": "Samy Pesse <samypesse@gmail.com>",
-    "main": "./lib/index.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/SamyPesse/octocat.js.git"
-    },
-    "dependencies": {
-        "q": "1.4.1",
-        "lodash": "3.10.1",
-        "request": "2.64.0",
-        "js-base64": "2.1.9",
-        "mime-types": "2.1.4",
-        "progress-stream": "1.1.1"
-    },
-    "devDependencies": {
-        "mocha": "1.18.2",
-        "should": "7.0.4"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha --reporter spec --timeout 15000"
-    },
-    "license": "Apache-2.0"
+  "name": "octocat",
+  "version": "0.11.0",
+  "description": "GitHub API client in Javascript (Node.js and Browser)",
+  "author": "Samy Pesse <samypesse@gmail.com>",
+  "main": "./lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SamyPesse/octocat.js.git"
+  },
+  "dependencies": {
+    "js-base64": "2.1.9",
+    "lodash": "3.10.1",
+    "mime-types": "2.1.4",
+    "progress-stream": "1.1.1",
+    "q": "1.4.1",
+    "request": "2.64.0",
+    "url-join": "^1.1.0"
+  },
+  "devDependencies": {
+    "mocha": "1.18.2",
+    "should": "7.0.4"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha --reporter spec --timeout 15000"
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Using `url.resolve` drops the required `/api/<version>` in the endpoint for github enterprise.  This should fix that issue.