### PR TITLE
Add method for integration installation to list repositories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var User = require('./user');
 var Organization = require('./organization');
 var Application = require('./application');
 var pagination = require('./pagination');
+var Installation = require('./installation');
 
 var GitHub = function(opts) {
     if (!(this instanceof GitHub)) return new GitHub(opts);
@@ -152,7 +153,7 @@ GitHub.prototype.repo = model.getter(Repository);
 GitHub.prototype.user = model.getter(User);
 GitHub.prototype.org = model.getter(Organization);
 GitHub.prototype.app = model.getter(Application);
-
+GitHub.prototype.installation = model.getter(Installation);
 
 // Get the authenticated user
 GitHub.prototype.me = function() {

--- a/lib/installation.js
+++ b/lib/installation.js
@@ -1,0 +1,33 @@
+var _ = require('lodash');
+
+var model = require('./model');
+var pagination = require('./pagination');
+
+var Installation = model.create(function() {});
+
+// Create a request url
+Installation.prototype.url = function() {
+    return _.compact(
+        ['/installation'].concat(_.toArray(arguments))
+    ).join('/');
+};
+
+// List installation repositories
+Installation.prototype.repos = pagination(function(userId) {
+    var params = {};
+    if (userId) {
+        params.user_id = userId;
+    }
+
+    return {
+        url: this.url('repositories'),
+        query: params,
+        opts: {
+            headers: {
+                Accept: 'application/vnd.github.machine-man-preview+json'
+            }
+        }
+    };
+});
+
+module.exports = Installation;

--- a/lib/installation.js
+++ b/lib/installation.js
@@ -3,6 +3,14 @@ var _ = require('lodash');
 var model = require('./model');
 var pagination = require('./pagination');
 
+// https://developer.github.com/v3/integrations/
+//
+// To access the integration API, we must provide a custom media type in the
+// Accept header.
+var DEFAULT_HEADERS = {
+    Accept: 'application/vnd.github.machine-man-preview+json'
+};
+
 var Installation = model.create(function() {});
 
 // Create a request url
@@ -23,9 +31,7 @@ Installation.prototype.repos = pagination(function(userId) {
         url: this.url('repositories'),
         query: params,
         opts: {
-            headers: {
-                Accept: 'application/vnd.github.machine-man-preview+json'
-            }
+            headers: DEFAULT_HEADERS
         }
     };
 });

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -100,10 +100,10 @@ module.exports = function(fn) {
         var client = this.client || this;
 
         // Apply page and perPage
-        request.url = request.url + '?' + querystring.stringify({
+        request.query = _.extend({
             page: opts.page,
             per_page: opts.perPage
-        });
+        }, request.query || {});
 
         // Create page object
         var page = new Page(client, request);

--- a/test/client.js
+++ b/test/client.js
@@ -1,4 +1,6 @@
 var should = require('should');
 var GitHub = require('../lib');
 
-module.exports = new GitHub();
+module.exports = new GitHub({
+    token: process.env.GITHUB_TOKEN
+});

--- a/test/installation.js
+++ b/test/installation.js
@@ -1,0 +1,19 @@
+var client = require('./client');
+
+if (!process.env.GITHUB_TOKEN) return;
+
+describe('Installation', function() {
+
+    it('should correctly get infos about installation repositories', function() {
+        var installation = client.installation()
+
+        return installation.repos()
+        .then(function(page) {
+            page.should.have.property('list');
+            page.should.have.property('next');
+            page.should.have.property('prev');
+        });
+    });
+
+});
+


### PR DESCRIPTION
This adds a method to list repositories that are accessible to the authenticated installation. It
also fixes the querystring parameters when passed from a pagination
object.

Relevant documentation: https://developer.github.com/v3/integrations/installations/