### PR TITLE
Fix absolute url in pagination links and merge params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var Organization = require('./organization');
 var Application = require('./application');
 var pagination = require('./pagination');
 var Installation = require('./installation');
+var isAbsoluteUrl = require('is-absolute-url');
 
 var GitHub = function(opts) {
     if (!(this instanceof GitHub)) return new GitHub(opts);
@@ -95,7 +96,7 @@ GitHub.prototype.onResponse = function(response, body, opts) {
 
 // Basic API HTTP request
 GitHub.prototype.request = function(httpMethod, method, params, opts) {
-    var uri, r, that = this;
+    var uri, r, parsedUrl, parsedParams, that = this;
     var d = Q.defer();
 
     opts = _.defaults(opts || {}, {
@@ -106,8 +107,15 @@ GitHub.prototype.request = function(httpMethod, method, params, opts) {
 
     httpMethod = httpMethod.toUpperCase();
 
-    uri = join(this.opts.endpoint, method);
-    if (httpMethod == 'GET') uri = uri + '?' + querystring.stringify(params || {});
+    uri = isAbsoluteUrl(method) ? method : join(this.opts.endpoint, method);
+
+    parsedUrl = url.parse(uri);
+    parsedParams = querystring.parse(parsedUrl.query);
+
+    uri = parsedUrl.protocol + '//' + parsedUrl.hostname + parsedUrl.pathname;
+    if (httpMethod == 'GET') {
+        uri = uri + '?' + querystring.stringify(_.extend({}, params, parsedParams));
+    }
 
     // Build request
     r = request(_.merge({

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,15 +107,7 @@ GitHub.prototype.request = function(httpMethod, method, params, opts) {
 
     httpMethod = httpMethod.toUpperCase();
 
-    uri = isAbsoluteUrl(method) ? method : join(this.opts.endpoint, method);
-
-    parsedUrl = url.parse(uri);
-    parsedParams = querystring.parse(parsedUrl.query);
-
-    uri = parsedUrl.protocol + '//' + parsedUrl.hostname + parsedUrl.pathname;
-    if (httpMethod == 'GET') {
-        uri = uri + '?' + querystring.stringify(_.extend({}, params, parsedParams));
-    }
+    uri = this.getURL(httpMethod, method, params);
 
     // Build request
     r = request(_.merge({
@@ -162,6 +154,21 @@ GitHub.prototype.user = model.getter(User);
 GitHub.prototype.org = model.getter(Organization);
 GitHub.prototype.app = model.getter(Application);
 GitHub.prototype.installation = model.getter(Installation);
+
+// Get the API URL to request
+GitHub.prototype.getURL = function (httpMethod, method, params) {
+    var uri = isAbsoluteUrl(method) ? method : join(this.opts.endpoint, method);
+
+    parsedUrl = url.parse(uri);
+    parsedParams = querystring.parse(parsedUrl.query);
+
+    uri = parsedUrl.protocol + '//' + parsedUrl.hostname + parsedUrl.pathname;
+    if (httpMethod == 'GET') {
+        uri = uri + '?' + querystring.stringify(_.extend({}, params, parsedParams));
+    }
+
+    return uri;
+};
 
 // Get the authenticated user
 GitHub.prototype.me = function() {

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -91,7 +91,7 @@ module.exports = function(fn) {
             opts = args.pop();
         }
         opts = _.defaults(opts, {
-            page: 0,
+            page: 1,
             perPage: 100
         });
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/SamyPesse/octocat.js.git"
   },
   "dependencies": {
+    "is-absolute-url": "^2.1.0",
     "js-base64": "2.1.9",
     "lodash": "3.10.1",
     "mime-types": "2.1.4",

--- a/test/installation.js
+++ b/test/installation.js
@@ -12,6 +12,9 @@ describe('Installation', function() {
             page.should.have.property('list');
             page.should.have.property('next');
             page.should.have.property('prev');
+
+            return page.next().then((page) => {
+            });
         });
     });
 

--- a/test/installation.js
+++ b/test/installation.js
@@ -13,7 +13,7 @@ describe('Installation', function() {
             page.should.have.property('next');
             page.should.have.property('prev');
 
-            return page.next().then((page) => {
+            return page.next().then(function(page) {
             });
         });
     });

--- a/test/issues.js
+++ b/test/issues.js
@@ -17,7 +17,12 @@ describe('Issues', function() {
 
         return repo.issues()
         .then(function(page) {
+            page.should.have.property('list');
+            page.should.have.property('next');
+            page.should.have.property('prev');
 
+            return page.next().then((page) => {
+            });
         });
     });
 

--- a/test/issues.js
+++ b/test/issues.js
@@ -21,7 +21,7 @@ describe('Issues', function() {
             page.should.have.property('next');
             page.should.have.property('prev');
 
-            return page.next().then((page) => {
+            return page.next().then(function (page) {
             });
         });
     });

--- a/test/issues.js
+++ b/test/issues.js
@@ -21,7 +21,7 @@ describe('Issues', function() {
             page.should.have.property('next');
             page.should.have.property('prev');
 
-            return page.next().then(function (page) {
+            return page.next().then(function(page) {
             });
         });
     });

--- a/test/pagination.js
+++ b/test/pagination.js
@@ -8,6 +8,9 @@ describe('Pagination', function() {
             page.should.have.property('list');
             page.should.have.property('next');
             page.should.have.property('prev');
+
+            return page.next().then((page) => {
+            });
         });
     });
 

--- a/test/pagination.js
+++ b/test/pagination.js
@@ -9,7 +9,7 @@ describe('Pagination', function() {
             page.should.have.property('next');
             page.should.have.property('prev');
 
-            return page.next().then((page) => {
+            return page.next().then(function(page) {
             });
         });
     });


### PR DESCRIPTION
Hi,

Firstly, this PR introduces [`is-absolute-url`](https://www.npmjs.com/package/is-absolute-url) to check if the URI needs to be join to the endpoint. This is required for pagination links that, I suspect, now returns the absolute path to the API instead of just the API method.

Secondly, the URI is parsed using `url` module to merge params between the query string params as returned by the pagination links and the params we might pass to the github client.

Lastly, a little change to defaults opts in pagination to set the page param to 1, as according to the [developer github documentation](https://developer.github.com/v3/#pagination):

> Note that page numbering is 1-based and that omitting the ?page parameter will return the first page.

which is confirmed by pagination links next that returns a `page=2` whenever we pass `page=0` in the initial call.