### PR TITLE
Use url.format to build the URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ GitHub.prototype.onResponse = function(response, body, opts) {
 
 // Basic API HTTP request
 GitHub.prototype.request = function(httpMethod, method, params, opts) {
-    var uri, r, parsedUrl, parsedParams, that = this;
+    var uri, r, that = this;
     var d = Q.defer();
 
     opts = _.defaults(opts || {}, {
@@ -159,12 +159,13 @@ GitHub.prototype.installation = model.getter(Installation);
 GitHub.prototype.getURL = function (httpMethod, method, params) {
     var uri = isAbsoluteUrl(method) ? method : join(this.opts.endpoint, method);
 
-    parsedUrl = url.parse(uri);
-    parsedParams = querystring.parse(parsedUrl.query);
+    var parsedUrl = url.parse(uri);
+    var parsedParams = querystring.parse(parsedUrl.query);
 
-    uri = parsedUrl.protocol + '//' + parsedUrl.hostname + parsedUrl.pathname;
+    uri = url.format(parsedUrl);
     if (httpMethod == 'GET') {
-        uri = uri + '?' + querystring.stringify(_.extend({}, params, parsedParams));
+        parsedUrl.search = '?' + querystring.stringify(_.extend({}, params, parsedParams));
+        uri = url.format(parsedUrl);
     }
 
     return uri;


### PR DESCRIPTION
This fix a bug in `getURL` when the port is different than 80, by using url.format() instead of building the url manually.

It also fix a noob mistake on two global variables while refactoring the code to build the URL in the `getURL` method.