### PR TITLE
handle absolute urls for previous/next from github

### DIFF
--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -36,6 +36,8 @@ var Page = function(client, request) {
 Page.prototype.update = function(uri) {
     var that = this;
 
+    uri = uri.replace(/^https:\/\/api\.github\.com/, '');
+    
     that.request.url = uri;
     return this.client.get(uri, this.request.query, this.request.opts)
     .then(function(response) {


### PR DESCRIPTION
It seems that the responses from Github have broken `page.next()`, `page.all()`, etc. This fixes it for me.